### PR TITLE
Correct error handling in `replaceWithFavorite()`

### DIFF
--- a/sonosifttt.js
+++ b/sonosifttt.js
@@ -76,12 +76,13 @@ app.post('/xmlrpc.php', ifttt, function(req, res) {
         for (var i = 0; i < players.length; i++) {
             var player = players[i];
             if (player.state.currentState === 'PLAYING') continue;
-            player.replaceWithFavorite(req.body.description, function(success) {
-                if (success)
-                    player.play();
-                else {
-                    console.log('didnt find it');
+            player.replaceWithFavorite(req.body.description, function(err) {
+                if (err) {
+                    console.error(err);
+                    return;
                 }
+                
+                player.play();
             });
         }
     }


### PR DESCRIPTION
With the `legacy` branch of `node-sonos-discovery`, the callback takes an error as the first argument, so null means good, not bad.